### PR TITLE
workaround reading sparse matrices with 0 rows

### DIFF
--- a/R/readMat.R
+++ b/R/readMat.R
@@ -2017,7 +2017,6 @@ setMethodS3("readMat", "default", function(con, maxLength=NULL, fixNames=TRUE, d
 
 
     mat5ReadMiMATRIX <- function(this, tag) {
-      # browser()
       if (verbose) {
         enter(verbose, level=-70, "Reading miMATRIX");
         on.exit(exit(verbose));

--- a/R/readMat.R
+++ b/R/readMat.R
@@ -2017,6 +2017,7 @@ setMethodS3("readMat", "default", function(con, maxLength=NULL, fixNames=TRUE, d
 
 
     mat5ReadMiMATRIX <- function(this, tag) {
+      # browser()
       if (verbose) {
         enter(verbose, level=-70, "Reading miMATRIX");
         on.exit(exit(verbose));
@@ -2208,7 +2209,7 @@ setMethodS3("readMat", "default", function(con, maxLength=NULL, fixNames=TRUE, d
           ir <- mat5ReadValues(this)$value;
 
           # Note that the indices for MAT v5 sparse arrays start at 0 (not 1).
-          if (any(ir < 0L | ir > nrow-1L)) {
+          if (any(ir < 0L) || (nrow>0 && any(ir > nrow-1L))) {
             stop("MAT v5 file format error: Some elements in row vector 'ir' (sparse arrays) are out of range [0,", nrow-1L, "].");
           }
 


### PR DESCRIPTION
* see https://github.com/HenrikBengtsson/R.matlab/issues/14
* AFAICS this should solve the issue. Of course the resultant empty R sparse
  matrix is not very useful, but at least such files can be read.