### PR TITLE
[DOC] Read v7.3 MAT files alternative

### DIFF
--- a/R/readMat.R
+++ b/R/readMat.R
@@ -90,8 +90,9 @@
 # \section{About MAT files saved in MATLAB using '-v7.3'}{
 #  This function does not support MAT files saved in MATLAB as
 #  \code{save('foo.mat', '-v7.3')}.
-#  Such MAT files are of a completely different file format [5,6]
-#  compared to those saved with, say, \code{'-v7'}.
+#  '-v7.3' MAT files are stored in a completely different format [5,6] named
+#  HDF5 and can be read with the package \code{rhdf5} available in 
+#  Bioconductor.
 # }
 #
 # \section{Reading MAT file structures input streams}{


### PR DESCRIPTION
Hi,
Thanks for your package for reading MAT files and interfacing with MATLAB from R.

This pull request just adds a comment on the `readMat` documentation. It suggests the use of `rhdf5` package from Bioconductor to read v7.3 MAT files. 

I don't think it is possible for R.matlab to depend on the rhdf5 package directly because it is not on CRAN, but suggesting it on the documentation makes sense to me, so users who need to read a v7.3 .mat file don't feel "abandoned".

Thanks for your time!