### PR TITLE
Recognize v7.3 mat files and suggest alternative

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Imports:
   utils,
   R.methodsS3 (>= 1.7.0),
   R.oo (>= 1.19.0),
-  R.utils (>= 2.1.0)
+  R.utils (>= 2.1.0),
+  h5
 Suggests:
   Matrix,
   SparseM

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,6 +13,7 @@ importFrom("R.oo", "getVersion")
 importFrom("R.oo", "getMaintainer")
 importFrom("R.oo", "startupMessage")
 importFrom("R.oo", "extend")
+importFrom("h5", "is.h5file")
 
 importFrom("R.utils", "isPackageInstalled")
 importFrom("R.utils", "cat") ## Multi-sources: R.utils, base

--- a/R/readMat.R
+++ b/R/readMat.R
@@ -2535,6 +2535,11 @@ setMethodS3("readMat", "default", function(con, maxLength=NULL, fixNames=TRUE, d
     # File in the R.io package to be used.
     con <- as.character(con);
 
+    # If it is a filename we can check if it is a v7.3 HDF5 Matlab file:
+    if (h5::is.h5file(con)) {
+        stop("Use the h5 package or the rhdf5 package to read new .mat files")
+    }
+
     # Now, assume that 'con' is a filename specifying a file to be opened.
     verbose && cat(verbose, level=-1, "Opens binary file: ", con);
     con <- file(con, open="rb");


### PR DESCRIPTION
I would say this is a valid starting point for issue #20.

Instead of manually parsing the H5 superblock, I opted for using the `h5::is.h5file`. I believe using the h5 package is a more simple and robust solution than writing a function to parse the HDF5 files. If you prefer to parse the H5 superblock, feel free to reject this patch.

Best,