### PR TITLE
Added more verbose error message

### DIFF
--- a/R/readMat.R
+++ b/R/readMat.R
@@ -2278,7 +2278,9 @@ setMethodS3("readMat", "default", function(con, maxLength = NULL, fixNames = TRU
     }
 
     if (header$version == "7.3") {
-      stop("Reading of MAT v7.3 files is not supported. If possible, save the data in MATLAB using 'save -V6'.")
+      stop(paste0("Reading of MAT v7.3 files is not supported. ", 
+                  "If possible, save the data in MATLAB using 'save -V6'.",
+                  "Alternatively, see ?readMat for HDF5 R readers.")
     }
 
     result <- list()


### PR DESCRIPTION
I always forget that newer mat files are HDF5 files in disguise.  I added more verbose errors for HDF5 readers, added to/enhancing fixing #23 or enhancing it.  Similar to `scipy` (https://scipy-cookbook.readthedocs.io/items/Reading_mat_files.html)
```
    raise NotImplementedError('Please use HDF reader for matlab v7.3 files')
NotImplementedError: Please use HDF reader for matlab v7.3 files
```
